### PR TITLE
getargspec is override,change to getfullargspec

### DIFF
--- a/allure-pytest/src/allure/utils.py
+++ b/allure-pytest/src/allure/utils.py
@@ -1,9 +1,9 @@
 import os
+import sys
 import inspect
 from itertools import product
 
 from allure_commons.constants import ALLURE_UNIQUE_LABELS
-
 
 ALLURE_LABEL_PREFIX = 'allure_label'
 ALLURE_LINK_PREFIX = 'allure_link'
@@ -84,8 +84,12 @@ def allure_full_name(nodeid):
 
 
 def step_parameters(func, *a, **kw):
-    all_names = inspect.getfullargspec(func).args
-    defaults = inspect.getfullargspec(func).defaults
+    if sys.version_info.major < 3:
+        all_names = inspect.getargspec(func).args
+        defaults = inspect.getargspec(func).defaults
+    else:
+        all_names = inspect.getfullargspec(func).args
+        defaults = inspect.getfullargspec(func).defaults
     args_part = [(n, str(v)) for n, v in zip(all_names, a)]
     kwarg_part = [(n, str(kw[n]) if n in kw else str(defaults[i])) for i, n in enumerate(all_names[len(a):])]
     return args_part + kwarg_part

--- a/allure-pytest/src/allure/utils.py
+++ b/allure-pytest/src/allure/utils.py
@@ -84,8 +84,8 @@ def allure_full_name(nodeid):
 
 
 def step_parameters(func, *a, **kw):
-    all_names = inspect.getargspec(func).args
-    defaults = inspect.getargspec(func).defaults
+    all_names = inspect.getfullargspec(func).args
+    defaults = inspect.getfullargspec(func).defaults
     args_part = [(n, str(v)) for n, v in zip(all_names, a)]
     kwarg_part = [(n, str(kw[n]) if n in kw else str(defaults[i])) for i, n in enumerate(all_names[len(a):])]
     return args_part + kwarg_part


### PR DESCRIPTION
fix `ValueError: Function has keyword-only parameters or annotations, use getfullargspec() API which can support them`

getargspec is override , change to getfullargspec